### PR TITLE
Reshape q-values in lowmem version

### DIFF
--- a/qvalue/qvalue.py
+++ b/qvalue/qvalue.py
@@ -90,7 +90,7 @@ def estimate(pv, m = None, verbose = False, lowmem = False, pi0 = None):
         qv = sp.zeros_like(qv)
         qv[p_ordered] = qv_temp
 
-        # reshape qvalues
-        qv = qv.reshape(original_shape)
+    # reshape qvalues
+    qv = qv.reshape(original_shape)
         
     return qv


### PR DESCRIPTION
The indentation of the reshape applied it only in the lowmem=False version
